### PR TITLE
BlendShapeのindexずれ対策

### DIFF
--- a/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MeshExporter.cs
@@ -232,7 +232,7 @@ namespace UniGLTF
             };
         }
 
-        public static void ExportMeshes(glTF gltf, int bufferIndex,
+        public static IEnumerable<(Mesh, glTFMesh, Dictionary<int, int>)> ExportMeshes(glTF gltf, int bufferIndex,
             List<MeshWithRenderer> unityMeshes, List<Material> unityMaterials,
             bool useSparseAccessorForMorphTarget,
             bool exportOnlyBlendShapePosition,
@@ -248,6 +248,8 @@ namespace UniGLTF
                     x.Renderer.name,
                     mesh, materials, unityMaterials, removeVertexColor);
 
+                var blendShapeIndexMap = new Dictionary<int, int>();
+                int exportBlendShapes = 0;
                 for (int j = 0; j < mesh.blendShapeCount; ++j)
                 {
                     var morphTarget = ExportMorphTarget(gltf, bufferIndex,
@@ -259,6 +261,10 @@ namespace UniGLTF
                         continue;
                     }
 
+                    // maybe skip
+
+                    blendShapeIndexMap.Add(j, exportBlendShapes++);
+
                     //
                     // all primitive has same blendShape
                     //
@@ -269,7 +275,7 @@ namespace UniGLTF
                     }
                 }
 
-                gltf.meshes.Add(gltfMesh);
+                yield return (mesh, gltfMesh, blendShapeIndexMap);
             }
         }
     }

--- a/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/gltfExporter.cs
@@ -91,6 +91,18 @@ namespace UniGLTF
             private set;
         }
 
+        /// <summary>
+        /// Mesh毎に、元のBlendShapeIndex => ExportされたBlendShapeIndex の対応を記録する
+        /// 
+        /// BlendShape が空の場合にスキップするので
+        /// </summary>
+        /// <value></value>
+        public Dictionary<Mesh, Dictionary<int, int>> MeshBlendShapeIndexMap
+        {
+            get;
+            private set;
+        }
+
         public List<Transform> Nodes
         {
             get;
@@ -261,8 +273,15 @@ namespace UniGLTF
                         return true;
                     })
                     .ToList();
-                MeshExporter.ExportMeshes(gltf, bufferIndex, unityMeshes, Materials, useSparseAccessorForMorphTarget,
-                                          ExportOnlyBlendShapePosition, removeVertexColor);
+
+                MeshBlendShapeIndexMap = new Dictionary<Mesh, Dictionary<int, int>>();
+                foreach (var (mesh, gltfMesh, blendShapeIndexMap) in MeshExporter.ExportMeshes(
+                        gltf, bufferIndex, unityMeshes, Materials, useSparseAccessorForMorphTarget,
+                        ExportOnlyBlendShapePosition, removeVertexColor))
+                {
+                    gltf.meshes.Add(gltfMesh);
+                    MeshBlendShapeIndexMap.Add(mesh, blendShapeIndexMap);
+                }
                 Meshes = unityMeshes.Select(x => x.Mesh).ToList();
                 #endregion
 

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMExporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMExporter.cs
@@ -100,10 +100,9 @@ namespace VRM
                 var avatar = master.BlendShapeAvatar;
                 if (avatar != null)
                 {
-                    var meshes = exporter.Meshes;
                     foreach (var x in avatar.Clips)
                     {
-                        gltf.extensions.VRM.blendShapeMaster.Add(x, exporter.Copy.transform, meshes);
+                        gltf.extensions.VRM.blendShapeMaster.Add(x, exporter);
                     }
                 }
             }


### PR DESCRIPTION
PRありがとうございました 👍 

BlendShape がスキップされる条件を満たすモデルが手元に無いので動作が未確認(該当しないモデルで実験)なのですが、
BlendShapeスキップによるBlendShapeClipのindexずれの対策です。

`remove_empty_morph_target` ブランチにMergeしてから 、`remove_empty_morph_target` を前進させると、
https://github.com/vrm-c/UniVRM/pull/487 も前進します。
ご存知の場合は失礼致しました。
